### PR TITLE
[feat] Auth UI 개선 및 대시보드 레이아웃 수정

### DIFF
--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -9,26 +9,28 @@ interface HeaderProps {
 }
 
 const Header = ({ onMenuClick }: HeaderProps) => {
-  const isSidebarCollapsed = useSidebarStore(
-    (state) => state.isSidebarCollapsed,
-  );
+  const isSidebarCollapsed = useSidebarStore((state) => state.isSidebarCollapsed);
 
   return (
-    <div
-      className={`top-0 right-0 left-0 h-8 bg-background transition-all duration-300 ${
+    <header
+      className={`top-0 right-0 left-0 h-8 bg-background ${
         isSidebarCollapsed ? "left-0" : "left-64"
       }`}
     >
-      <div className="flex h-full items-center px-4">
-        <button
-          onClick={onMenuClick}
-          className="p-2 hover:bg-muted rounded-full"
-        >
-          <Menu className="h-5 w-5" />
-        </button>
-        <div className="flex-1" />
+      <div className="flex items-center justify-between h-full">
+        <div className="flex items-center gap-3">
+          <button
+            onClick={onMenuClick}
+            className="p-1.5 hover:bg-muted/60 rounded-md ml-2"
+          >
+            <Menu className="h-4 w-4" />
+          </button>
+        </div>
+        <div className="mr-1">
+          <UserMenu />
+        </div>
       </div>
-    </div>
+    </header>
   );
 };
 

--- a/src/components/layout/Sidebar.tsx
+++ b/src/components/layout/Sidebar.tsx
@@ -1,18 +1,12 @@
 import React, { useState } from "react";
 import { LayoutDashboard } from "lucide-react";
 import { cn } from "@/lib/utils.ts";
-import UserMenu from "@/components/layout/UserMenu.tsx";
 import useSidebarStore from "@/store/useSidebarStore.tsx";
-import { useAuth } from "@/contexts/AuthContext.tsx";
 
 interface MenuItem {
   icon: React.ElementType;
   label: string;
   href: string;
-}
-
-interface SidebarProps {
-  onCollapse: () => void;
 }
 
 const Sidebar = () => {
@@ -43,7 +37,6 @@ const Sidebar = () => {
       >
         {/* 메뉴 항목들 */}
         <div className="p-4">
-          <UserMenu />
           <div className="mt-4">
             {menuItems.map((item) => (
               <a

--- a/src/components/layout/UserMenu.tsx
+++ b/src/components/layout/UserMenu.tsx
@@ -27,11 +27,11 @@ const UserMenu = () => {
       if (error) {
         throw new Error(error.message); // 오류 발생 시 예외 던지기
       }
-      window.location.reload();
     } catch (err) {
       alert(`로그아웃 실패: ${(err as Error).message}`);
     } finally {
       setIsLoggingOut(false);
+      window.location.reload();
     }
   };
 

--- a/src/components/modal/LoginModal.tsx
+++ b/src/components/modal/LoginModal.tsx
@@ -11,8 +11,9 @@ import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { supabase } from "@/supabase.ts";
-import useSidebarStore from "@/store/useSidebarStore.tsx";
 import { useToast } from "@/hooks/use-toast.ts";
+import {AuthModalProps} from "@/components/modal/SignupModal.tsx";
+
 
 const AUTH_ERROR_MESSAGES = {
   TITLE: "로그인 실패",
@@ -21,11 +22,11 @@ const AUTH_ERROR_MESSAGES = {
   UNKNOWN_ERROR: "로그인 중 오류가 발생했습니다. 다시 시도해주세요.",
 };
 
-const LoginModal = ({ isOpen, onOpenChange }) => {
+const LoginModal = ({ isOpen, onOpenChange } : AuthModalProps) => {
   const { toast } = useToast();
-  const setIsSidebarOpen = useSidebarStore((state) => state.setIsSidebarOpen);
-  const [email, setEmail] = useState("");
-  const [password, setPassword] = useState("");
+
+  const [email, setEmail] = useState<string>("");
+  const [password, setPassword] = useState<string>("");
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
@@ -47,7 +48,6 @@ const LoginModal = ({ isOpen, onOpenChange }) => {
         return;
       }
       onOpenChange(false);
-      setIsSidebarOpen();
     } catch (err) {
       toast({
         variant: "destructive",
@@ -55,6 +55,7 @@ const LoginModal = ({ isOpen, onOpenChange }) => {
         description: AUTH_ERROR_MESSAGES.UNKNOWN_ERROR,
       });
     }
+    window.location.reload();
   };
 
   return (

--- a/src/components/modal/SignupModal.tsx
+++ b/src/components/modal/SignupModal.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import React, { useState } from "react";
 import {
   Dialog,
   DialogContent,
@@ -12,47 +12,59 @@ import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { Alert, AlertDescription } from "@/components/ui/alert";
 import { supabase } from "@/supabase.ts";
+import {useToast} from "@/hooks/use-toast.ts";
 
-interface formData {
+
+
+export interface AuthModalProps {
+  isOpen: boolean;
+  onOpenChange: (isOpen: boolean) => void;
+}
+
+export interface SignUpForm {
+  name: string;
   email: string;
   password: string;
   confirmPassword: string;
 }
 
-const SignupModal = ({ isOpen, onOpenChange }) => {
-  const [formData, setFormData] = useState({
+const SignupModal = ({ isOpen, onOpenChange } :AuthModalProps) => {
+  const { toast } = useToast();
+
+  const [signUpForm, setSignUpForm] = useState<SignUpForm>({
+    name: "",
     email: "",
     password: "",
     confirmPassword: "",
   });
-  const [error, setError] = useState("");
+  const [error, setError] = useState<string>("");
 
   const handleChange = (e) => {
     const { name, value } = e.target;
-    setFormData((prev) => ({
+    setSignUpForm((prev) => ({
       ...prev,
       [name]: value,
     }));
-    setError(""); // 입력이 변경되면 에러 메시지 초기화
+    setError("");
   };
 
   const validateForm = () => {
-    if (!formData.email || !formData.password || !formData.confirmPassword) {
+    if (!signUpForm.email || !signUpForm.password || !signUpForm.confirmPassword || !signUpForm.name) {
       setError("모든 필드를 입력해주세요.");
       return false;
     }
 
-    if (!formData.email.includes("@")) {
+    if (!signUpForm.email.includes("@")) {
       setError("유효한 이메일 주소를 입력해주세요.");
       return false;
     }
 
-    if (formData.password.length < 6) {
+    if (signUpForm.password.length < 6) {
       setError("비밀번호는 최소 6자 이상이어야 합니다.");
       return false;
     }
 
-    if (formData.password !== formData.confirmPassword) {
+    if (signUpForm.password !== signUpForm.confirmPassword) {
       setError("비밀번호가 일치하지 않습니다.");
       return false;
     }
@@ -68,17 +80,36 @@ const SignupModal = ({ isOpen, onOpenChange }) => {
     }
 
     try {
-      console.log("Signup attempt with:", formData);
-      // 회원가입 성공 시
       const { error } = await supabase.auth.signUp({
-        email: formData.email,
-        password: formData.password,
+        email: signUpForm.email,
+        password: signUpForm.password,
+        options: {
+          data: { name: signUpForm.name },
+        }
       });
-      // TODO: 성공 후 toast
-      onOpenChange(false);
+
+      if (error) {
+        if (error.message.includes("User already registered")) {
+          setError("이미 사용 중인 이메일입니다.")
+        }
+        return;
+      } else {
+        toast({
+          variant: "default",
+          title: "환영합니다! 🎉",
+          description: `${signUpForm.name}님, 함께 시작해볼까요?`,
+        });
+        onOpenChange(false);
+      }
     } catch (err) {
-      setError("회원가입 중 오류가 발생했습니다.");
+      toast({
+        variant: "destructive",
+        title: "회원가입 실패",
+        description: "회원가입 중 오류가 발생했습니다.",
+      });
     }
+
+    window.location.reload();
   };
 
   return (
@@ -91,59 +122,67 @@ const SignupModal = ({ isOpen, onOpenChange }) => {
           <DialogTitle>회원가입</DialogTitle>
           <DialogDescription>새로운 계정을 만들어보세요</DialogDescription>
         </DialogHeader>
-        <form onSubmit={handleSubmit} className="space-y-4">
-          {error && (
-            <Alert variant="destructive">
-              <AlertDescription>{error}</AlertDescription>
-            </Alert>
-          )}
-          <div className="space-y-2">
-            <Label htmlFor="email">이메일</Label>
-            <Input
-              id="email"
-              name="email"
-              type="email"
-              placeholder="example@email.com"
-              value={formData.email}
-              onChange={handleChange}
-              required
-            />
-          </div>
-          <div className="space-y-2">
-            <Label htmlFor="password">비밀번호</Label>
-            <Input
-              id="password"
-              name="password"
-              type="password"
-              value={formData.password}
-              onChange={handleChange}
-              required
-              placeholder="6자 이상 입력해주세요"
-            />
-          </div>
-          <div className="space-y-2">
-            <Label htmlFor="confirmPassword">비밀번호 확인</Label>
-            <Input
-              id="confirmPassword"
-              name="confirmPassword"
-              type="password"
-              value={formData.confirmPassword}
-              onChange={handleChange}
-              required
-              placeholder="비밀번호를 한번 더 입력해주세요"
-            />
-          </div>
-          <div className="flex justify-end space-x-2">
-            <Button
-              type="button"
-              variant="outline"
-              onClick={() => onOpenChange(false)}
-            >
-              취소
-            </Button>
-            <Button type="submit">가입하기</Button>
-          </div>
-        </form>
+          <form onSubmit={handleSubmit} className="space-y-4">
+              {error && (
+                  <Alert variant="destructive">
+                      <AlertDescription>{error}</AlertDescription>
+                  </Alert>
+              )}
+              <div className="space-y-2">
+                  <Label htmlFor="name">이름</Label>
+                  <Input
+                      id="name"
+                      name="name"
+                      type="text"
+                      placeholder="이름을 입력해주세요"
+                      value={signUpForm.name}
+                      onChange={handleChange}
+                  />
+              </div>
+              <div className="space-y-2">
+                  <Label htmlFor="email">이메일</Label>
+                  <Input
+                      id="email"
+                      name="email"
+                      type="text"
+                      placeholder="example@email.com"
+                      value={signUpForm.email}
+                      onChange={handleChange}
+                  />
+              </div>
+              <div className="space-y-2">
+                  <Label htmlFor="password">비밀번호</Label>
+                  <Input
+                      id="password"
+                      name="password"
+                      type="password"
+                      value={signUpForm.password}
+                      onChange={handleChange}
+                      placeholder="6자 이상 입력해주세요"
+                  />
+              </div>
+              <div className="space-y-2">
+                  <Label htmlFor="confirmPassword">비밀번호 확인</Label>
+                  <Input
+                      id="confirmPassword"
+                      name="confirmPassword"
+                      type="password"
+                      value={signUpForm.confirmPassword}
+                      onChange={handleChange}
+                      placeholder="비밀번호를 한번 더 입력해주세요"
+                  />
+              </div>
+              <div className="flex justify-end space-x-2">
+                  <Button
+                      type="button"
+                      variant="outline"
+                      onClick={() => onOpenChange(false)}
+                  >
+                      취소
+                  </Button>
+                  <Button type="submit">가입하기</Button>
+              </div>
+          </form>
       </DialogContent>
     </Dialog>
   );

--- a/src/components/ui/toast.tsx
+++ b/src/components/ui/toast.tsx
@@ -15,7 +15,7 @@ const ToastViewport = React.forwardRef<
     ref={ref}
     className={cn(
       "fixed top-0 z-[100] flex max-h-screen w-full flex-col-reverse p-4 sm:bottom-0 sm:right-0 sm:top-auto sm:flex-col md:max-w-[420px]",
-      className,
+      className
     )}
     {...props}
   />
@@ -23,25 +23,27 @@ const ToastViewport = React.forwardRef<
 ToastViewport.displayName = ToastPrimitives.Viewport.displayName;
 
 const toastVariants = cva(
-  "group pointer-events-auto relative flex w-full items-center justify-between space-x-2 overflow-hidden rounded-md border p-4 pr-6 shadow-lg transition-all data-[swipe=cancel]:translate-x-0 data-[swipe=end]:translate-x-[var(--radix-toast-swipe-end-x)] data-[swipe=move]:translate-x-[var(--radix-toast-swipe-move-x)] data-[swipe=move]:transition-none data-[state=open]:animate-in data-[state=closed]:animate-out data-[swipe=end]:animate-out data-[state=closed]:fade-out-80 data-[state=closed]:slide-out-to-right-full data-[state=open]:slide-in-from-top-full data-[state=open]:sm:slide-in-from-bottom-full",
+  "group pointer-events-auto relative flex w-full items-center justify-between overflow-hidden rounded-2xl border-l-[6px] bg-white p-6 pr-8 shadow-lg transition-all dark:bg-gray-900 shadow-lg transition-all data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-80 data-[state=open]:slide-in-from-bottom-full data-[state=closed]:slide-out-to-right-full",
   {
     variants: {
       variant: {
-        default: "border bg-background text-foreground",
-        destructive:
-          "destructive group border-destructive bg-destructive text-destructive-foreground",
+        default: "border-l-gray-500 text-gray-900 dark:text-gray-100",
+        success: "border-l-emerald-500 text-emerald-700 dark:text-emerald-500",
+        destructive: "border-l-red-500 text-red-700 dark:text-red-500",
+        warning: "border-l-amber-500 text-amber-700 dark:text-amber-500",
+        info: "border-l-sky-500 text-sky-700 dark:text-sky-500",
       },
     },
     defaultVariants: {
       variant: "default",
     },
-  },
+  }
 );
 
 const Toast = React.forwardRef<
   React.ElementRef<typeof ToastPrimitives.Root>,
   React.ComponentPropsWithoutRef<typeof ToastPrimitives.Root> &
-    VariantProps<typeof toastVariants>
+  VariantProps<typeof toastVariants>
 >(({ className, variant, ...props }, ref) => {
   return (
     <ToastPrimitives.Root
@@ -60,12 +62,18 @@ const ToastAction = React.forwardRef<
   <ToastPrimitives.Action
     ref={ref}
     className={cn(
-      "inline-flex h-8 shrink-0 items-center justify-center rounded-md border bg-transparent px-3 text-sm font-medium transition-colors hover:bg-secondary focus:outline-none focus:ring-1 focus:ring-ring disabled:pointer-events-none disabled:opacity-50 group-[.destructive]:border-muted/40 group-[.destructive]:hover:border-destructive/30 group-[.destructive]:hover:bg-destructive group-[.destructive]:hover:text-destructive-foreground group-[.destructive]:focus:ring-destructive",
-      className,
+      "inline-flex h-8 items-center justify-center rounded-lg px-3 text-sm font-medium transition-colors",
+      "bg-transparent hover:bg-gray-100 dark:hover:bg-gray-800",
+      "border border-gray-200 dark:border-gray-800",
+      "focus:outline-none focus:ring-2 focus:ring-gray-400 focus:ring-offset-2 dark:focus:ring-gray-600",
+      "disabled:pointer-events-none disabled:opacity-50",
+      "group-[.destructive]:border-red-500 group-[.destructive]:hover:border-red-500 group-[.destructive]:hover:bg-red-50 group-[.destructive]:focus:ring-red-500",
+      className
     )}
     {...props}
   />
 ));
+
 ToastAction.displayName = ToastPrimitives.Action.displayName;
 
 const ToastClose = React.forwardRef<
@@ -75,8 +83,12 @@ const ToastClose = React.forwardRef<
   <ToastPrimitives.Close
     ref={ref}
     className={cn(
-      "absolute right-1 top-1 rounded-md p-1 text-foreground/50 opacity-0 transition-opacity hover:text-foreground focus:opacity-100 focus:outline-none focus:ring-1 group-hover:opacity-100 group-[.destructive]:text-red-300 group-[.destructive]:hover:text-red-50 group-[.destructive]:focus:ring-red-400 group-[.destructive]:focus:ring-offset-red-600",
-      className,
+      "absolute right-2 top-2 rounded-md p-1",
+      "text-gray-400 opacity-0 transition-opacity",
+      "hover:text-gray-900 dark:hover:text-gray-100",
+      "focus:opacity-100 focus:outline-none focus:ring-2",
+      "group-hover:opacity-100",
+      className
     )}
     toast-close=""
     {...props}
@@ -84,6 +96,7 @@ const ToastClose = React.forwardRef<
     <X className="h-4 w-4" />
   </ToastPrimitives.Close>
 ));
+
 ToastClose.displayName = ToastPrimitives.Close.displayName;
 
 const ToastTitle = React.forwardRef<
@@ -92,7 +105,7 @@ const ToastTitle = React.forwardRef<
 >(({ className, ...props }, ref) => (
   <ToastPrimitives.Title
     ref={ref}
-    className={cn("text-sm font-semibold [&+div]:text-xs text-left", className)}
+    className={cn("text-base font-semibold text-left", className)}
     {...props}
   />
 ));

--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -1,8 +1,6 @@
 import ProjectCard from '@/components/dashBoard/ProjectCard.tsx';
 import SearchBar from '@/components/dashBoard/SearchBar.tsx';
 import { useEffect, useState } from 'react';
-import { ProjectDialog } from '@/components/dashBoard/ProjectDialog.tsx';
-import { Label } from '@/components/ui/label.tsx';
 import { Switch } from '@/components/ui/switch.tsx';
 import { fetchProjects } from '@/fecthers/project/project.tsx';
 import useDashBoardStore from '../store/useDashBoardStore.tsx';
@@ -10,6 +8,7 @@ import { useQuery } from '@tanstack/react-query';
 import { useAuth } from '@/contexts/AuthContext.tsx';
 import { Project } from '@/types/project.model.tsx';
 import { mapProjectDTOsToProjects } from '@/mappers/project.mapper.ts';
+import {Eye, Plus} from "lucide-react";
 
 export default function Dashboard() {
   const [projects, setProjects] = useState<Project[] | undefined>([]);
@@ -33,42 +32,45 @@ export default function Dashboard() {
   }, [projectsData]);
 
   return (
-    <div className="w-full min-h-screen bg-background p-3 lg:p-8">
+    <div className="w-full min-h-screen bg-background ">
       {/* Glass-morphism Header */}
-      <div className="rounded-xl bg-background/60 backdrop-blur-lg border shadow-md p-3 mb-8">
+      <div className="bg-white/60 dark:bg-gray-800/60 backdrop-blur-lg shadow-lg p-4 mb-8 rounded-xl">
         <div className="flex flex-col space-y-6 md:flex-row md:items-center md:justify-between md:space-y-0">
           <div className="flex flex-col space-y-4 md:flex-row md:items-center md:space-x-6 md:space-y-0">
-            <h1 className="text-3xl font-bold bg-gradient-to-r from-primary to-primary/70 bg-clip-text text-transparent">
+            <h1
+              className="text-3xl font-bold bg-gradient-to-r from-primary via-primary/90 to-primary/70 bg-clip-text text-transparent">
               TaskFlow
             </h1>
             {user && (
               <div className="w-full md:w-auto md:min-w-[320px]">
-                <SearchBar />
+                <div className="bg-white dark:bg-gray-700 shadow-sm rounded-lg">
+                  <SearchBar/>
+                </div>
               </div>
             )}
           </div>
 
           {user && (
-            <div className="flex flex-col space-y-4 sm:flex-row sm:items-center sm:space-x-6 sm:space-y-0">
-              <div className="flex items-center gap-2 bg-gray-100 dark:bg-gray-800 p-2 rounded-lg">
+            <div className="flex flex-col space-y-4 sm:flex-row sm:items-center sm:space-x-4 sm:space-y-0">
+              {/* 토글 스위치 */}
+              <div className="flex items-center gap-2 h-10 px-3">
                 <Switch
-                  id="mode"
                   checked={checked}
                   onCheckedChange={setChecked}
-                  className="relative inline-flex h-6 w-12 items-center rounded-full border bg-gray-300 transition-colors
-             data-[state=checked]:bg-primary"
+                  className="relative inline-flex h-6 w-11 items-center rounded-full bg-gray-200 dark:bg-gray-700 data-[state=checked]:bg-primary"
                 >
                   <span
-                    className="inline-block h-4 w-4 transform rounded-full bg-white shadow-md transition-transform
-               data-[state=checked]:translate-x-6 translate-x-1"
-                  />
+                    className="inline-block h-5 w-5 transform rounded-full bg-white transition-transform data-[state=checked]:translate-x-5 translate-x-0.5"/>
                 </Switch>
-                <Label htmlFor="mode" className="text-sm font-medium cursor-pointer">
-                  숨긴 프로젝트 보기
-                </Label>
+                <span className="text-sm font-medium text-gray-700 dark:text-gray-200">숨긴 프로젝트 보기</span>
               </div>
 
-              <ProjectDialog />
+              {/* 새 프로젝트 버튼 */}
+              <button
+                className="flex items-center gap-2 bg-primary/80 hover:bg-primary dark:bg-primary/90 dark:hover:bg-primary backdrop-blur-sm shadow-sm text-white h-10 px-3 rounded-full transition-colors">
+                <Plus className="w-4 h-4"/>
+                <span className="text-sm font-medium">새 프로젝트</span>
+              </button>
             </div>
           )}
         </div>
@@ -78,7 +80,7 @@ export default function Dashboard() {
       <div className="grid gap-6 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 auto-rows-max">
         {projects?.map((project, index) => (
           <div key={index} className="transform transition-all duration-200 hover:-translate-y-1 hover:shadow-lg">
-            <ProjectCard project={project} handleHidden={refetch} />
+            <ProjectCard project={project} handleHidden={refetch}/>
           </div>
         ))}
       </div>


### PR DESCRIPTION
## 개요  
Auth UI 개선 및 대시보드 레이아웃 수정

## 작업 내용  
- 회원가입 시 사용자 이름 필드 추가
- 회원가입, 로그아웃, 로그인 시 toast 알림, 새로고침 추가
-  props, state ts 적용
- UserMenu 사이드바에서 헤더로 이동
- 대시보드 레이아웃 수정
